### PR TITLE
Versão para impressão em produção

### DIFF
--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -12,6 +12,7 @@ const IgnorePlugin = require('webpack/lib/IgnorePlugin');
 const DedupePlugin = require('webpack/lib/optimize/DedupePlugin');
 const UglifyJsPlugin = require('webpack/lib/optimize/UglifyJsPlugin');
 const WebpackMd5Hash = require('webpack-md5-hash');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 /**
  * Webpack Constants
@@ -174,6 +175,10 @@ module.exports = function(env) {
         /angular2-hmr/,
         helpers.root('config/modules/angular2-hmr-prod.js')
       ),
+
+      new CopyWebpackPlugin([
+            { from: 'src/print', to: 'print' }
+        ])
 
       /**
        * Plugin: IgnorePlugin


### PR DESCRIPTION
Levando os arquivos estáticos para a versão de impressão do relatório para a pasta dist com webpack.